### PR TITLE
Fix the charter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ See [the security doc](./SECURITY.md) for reporting process and disclosure commu
 
 Unless otherwise noted, code and docs of OCI projects are released under the [Apache 2.0 license](LICENSE).
 
-[charter]: https://www.opencontainers.org/about/governance
+[charter]: https://github.com/opencontainers/tob/blob/main/CHARTER.md
 [dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
 [rfc5545]: https://tools.ietf.org/html/rfc5545


### PR DESCRIPTION
The charter link points to a dead link on the website. The website currently points to the TOB repo, so this change mirrors that.